### PR TITLE
Pypdf

### DIFF
--- a/elikopy/core.py
+++ b/elikopy/core.py
@@ -625,13 +625,13 @@ class Elikopy:
             output, error = process.communicate()
 
             # 2) merge both pdfs
-            from PyPDF2 import PdfFileMerger
+            from pypdf import PdfMerger
             for p in patient_list:
                 patient_path = p
                 if os.path.exists(folder_path + '/subjects/' + patient_path + '/dMRI/preproc/eddy/' + patient_path + '_eddy_corr.qc/qc_updated.pdf'):
                     pdfs = [folder_path + '/subjects/' + patient_path + '/dMRI/preproc/quality_control/qc_report.pdf',
                             folder_path + '/subjects/' + patient_path + '/dMRI/preproc/eddy/' + patient_path + '_eddy_corr.qc/qc_updated.pdf']
-                    merger = PdfFileMerger()
+                    merger = PdfMerger()
                     for pdf in pdfs:
                         merger.append(pdf)
                     merger.write(folder_path + '/subjects/' + patient_path + '/quality_control.pdf')

--- a/elikopy/individual_subject_processing.py
+++ b/elikopy/individual_subject_processing.py
@@ -1601,9 +1601,9 @@ def dti_solo(folder_path, p, maskType="brain_mask_dilated", report=True):
             shutil.copyfile(qc_path + '/qc_report.pdf', folder_path + '/subjects/' + patient_path + '/quality_control.pdf')
         else:
             """Merge with QC of preproc""";
-            from PyPDF2 import PdfFileMerger
+            from pypdf import PdfMerger
             pdfs = [folder_path + '/subjects/' + patient_path + '/quality_control.pdf', qc_path + '/qc_report.pdf']
-            merger = PdfFileMerger()
+            merger = PdfMerger()
             for pdf in pdfs:
                 merger.append(pdf)
             merger.write(folder_path + '/subjects/' + patient_path + '/quality_control_dti.pdf')
@@ -1870,7 +1870,7 @@ def white_mask_solo(folder_path, p, maskType, corr_gibbs=True, core_count=1, deb
     matplotlib.use('Agg')
     import matplotlib.pyplot as plt
     from fpdf import FPDF
-    from PyPDF2 import PdfFileMerger
+    from pypdf import PdfMerger
 
     T1_path = folder_path + '/subjects/' + patient_path + "/T1/" + patient_path + '_T1.nii.gz'
     T1gibbs_path = folder_path + '/subjects/' + patient_path + "/T1/" + patient_path + '_T1_gibbscorrected.nii.gz'
@@ -2019,7 +2019,7 @@ def white_mask_solo(folder_path, p, maskType, corr_gibbs=True, core_count=1, deb
         shutil.copyfile(qc_path + '/qc_report.pdf', folder_path + '/subjects/' + patient_path + '/quality_control.pdf')
     else:
         pdfs = [folder_path + '/subjects/' + patient_path + '/quality_control.pdf', qc_path + '/qc_report.pdf']
-        merger = PdfFileMerger()
+        merger = PdfMerger()
         for pdf in pdfs:
             merger.append(pdf)
         merger.write(folder_path + '/subjects/' + patient_path + '/quality_control_wm.pdf')
@@ -2267,9 +2267,9 @@ def noddi_solo(folder_path, p, maskType="brain_mask_dilated", lambda_iso_diff=3.
         shutil.copyfile(qc_path + '/qc_report.pdf', folder_path + '/subjects/' + patient_path + '/quality_control.pdf')
     else:
         """Merge with QC of preproc""";
-        from PyPDF2 import PdfFileMerger
+        from pypdf import PdfMerger
         pdfs = [folder_path + '/subjects/' + patient_path + '/quality_control.pdf', qc_path + '/qc_report.pdf']
-        merger = PdfFileMerger()
+        merger = PdfMerger()
         for pdf in pdfs:
             merger.append(pdf)
         merger.write(folder_path + '/subjects/' + patient_path + '/quality_control_noddi.pdf')
@@ -2566,9 +2566,9 @@ def diamond_solo(folder_path, p, core_count=4, reportOnly=False, maskType="brain
         shutil.copyfile(qc_path + '/qc_report.pdf', folder_path + '/subjects/' + patient_path + '/quality_control.pdf')
     else:
         """Merge with QC of preproc""";
-        from PyPDF2 import PdfFileMerger
+        from pypdf import PdfMerger
         pdfs = [folder_path + '/subjects/' + patient_path + '/quality_control.pdf', qc_path + '/qc_report.pdf']
-        merger = PdfFileMerger()
+        merger = PdfMerger()
         for pdf in pdfs:
             merger.append(pdf)
         merger.write(folder_path + '/subjects/' + patient_path + '/quality_control_diamond.pdf')
@@ -2941,9 +2941,9 @@ def mf_solo(folder_path, p, dictionary_path, core_count=1, maskType="brain_mask_
                             folder_path + '/subjects/' + patient_path + '/quality_control.pdf')
         else:
             """Merge with QC of preproc""";
-            from PyPDF2 import PdfFileMerger
+            from pypdf import PdfMerger
             pdfs = [folder_path + '/subjects/' + patient_path + '/quality_control.pdf', qc_path + '/qc_report.pdf']
-            merger = PdfFileMerger()
+            merger = PdfMerger()
             for pdf in pdfs:
                 merger.append(pdf)
             merger.write(folder_path + '/subjects/' + patient_path + '/quality_control_mf.pdf')
@@ -3443,9 +3443,9 @@ def ivim_solo(folder_path, p, core_count=1, G1Ball_2_lambda_iso=7e-9, G1Ball_1_l
         shutil.copyfile(qc_path + '/qc_report.pdf', folder_path + '/subjects/' + patient_path + '/quality_control.pdf')
     else:
         """Merge with QC of preproc""";
-        from PyPDF2 import PdfFileMerger
+        from pypdf import PdfMerger
         pdfs = [folder_path + '/subjects/' + patient_path + '/quality_control.pdf', qc_path + '/qc_report.pdf']
-        merger = PdfFileMerger()
+        merger = PdfMerger()
         for pdf in pdfs:
             merger.append(pdf)
         merger.write(folder_path + '/subjects/' + patient_path + '/quality_control_ivim.pdf')
@@ -3710,9 +3710,9 @@ def verdict_solo(folder_path, p, core_count=1, small_delta=0.003, big_delta=0.03
         shutil.copyfile(qc_path + '/qc_report.pdf', folder_path + '/subjects/' + patient_path + '/quality_control.pdf')
     else:
         """Merge with QC of preproc""";
-        from PyPDF2 import PdfFileMerger
+        from pypdf import PdfMerger
         pdfs = [folder_path + '/subjects/' + patient_path + '/quality_control.pdf', qc_path + '/qc_report.pdf']
-        merger = PdfFileMerger()
+        merger = PdfMerger()
         for pdf in pdfs:
             merger.append(pdf)
         merger.write(folder_path + '/subjects/' + patient_path + '/quality_control_verdict.pdf')

--- a/elikopy/utils.py
+++ b/elikopy/utils.py
@@ -1402,7 +1402,7 @@ def merge_all_reports(folder_path):
 
     :param folder_path: Path to the root folder of the study.
     """
-    from PyPDF2 import PdfFileWriter, PdfFileReader
+    from pypdf import PdfWriter, PdfReader
     import json
     import os
 
@@ -1410,17 +1410,17 @@ def merge_all_reports(folder_path):
     with open(dest_success, 'r') as f:
         patient_list = json.load(f)
 
-    writer = PdfFileWriter()
+    writer = PdfWriter()
 
     for p in patient_list:
         patient_path = os.path.splitext(p)[0]
         pdf_path = folder_path + '/subjects/' + patient_path + '/quality_control.pdf'
         if (os.path.exists(pdf_path)):
-            reader = PdfFileReader(pdf_path)
-            for i in range(reader.numPages):
-                page = reader.getPage(i)
-                page.compressContentStreams()
-                writer.addPage(page)
+            reader = PdfReader(pdf_path)
+            for i in range(len(reader.pages)):
+                page = reader.pages[i]
+                page.compress_content_streams()
+                writer.add_page(page)
 
     with open(folder_path + '/quality_control_all_tmp.pdf', 'wb') as f:
         writer.write(f)
@@ -1444,7 +1444,7 @@ def merge_all_specific_reports(folder_path, merge_wm_report=False, merge_legacy_
     :param merge_wm_report: Select wm report.
     :param merge_legacy_report: Select legacy report.
     """
-    from PyPDF2 import PdfFileWriter, PdfFileReader
+    from pypdf import PdfWriter, PdfReader
     import json
     import os
 
@@ -1453,10 +1453,10 @@ def merge_all_specific_reports(folder_path, merge_wm_report=False, merge_legacy_
         patient_list = json.load(f)
 
     if merge_wm_report:
-        wm_writer = PdfFileWriter()
+        wm_writer = PdfWriter()
 
     if merge_legacy_report:
-        legacy_writer = PdfFileWriter()
+        legacy_writer = PdfWriter()
 
     for p in patient_list:
         patient_path = os.path.splitext(p)[0]
@@ -1465,21 +1465,21 @@ def merge_all_specific_reports(folder_path, merge_wm_report=False, merge_legacy_
             pdf_path = folder_path + '/subjects/' + patient_path + \
                 '/masks/quality_control/qc_report.pdf'
             if (os.path.exists(pdf_path)):
-                reader = PdfFileReader(pdf_path)
-                for i in range(reader.numPages):
-                    page = reader.getPage(i)
-                    page.compressContentStreams()
-                    wm_writer.addPage(page)
+                reader = PdfReader(pdf_path)
+                for i in range(len(reader.pages)):
+                    page = reader.pages[i]
+                    page.compress_content_streams()
+                    wm_writer.add_page(page)
 
         if merge_legacy_report:
             pdf_path = folder_path + '/subjects/' + patient_path + \
                 '/report/report_' + patient_path + '.pdf'
             if (os.path.exists(pdf_path)):
-                reader = PdfFileReader(pdf_path)
-                for i in range(reader.numPages):
-                    page = reader.getPage(i)
-                    page.compressContentStreams()
-                    legacy_writer.addPage(page)
+                reader = PdfReader(pdf_path)
+                for i in range(len(reader.pages)):
+                    page = reader.pages[i]
+                    page.compress_content_streams()
+                    legacy_writer.add_page(page)
 
     if merge_wm_report:
         with open(folder_path + '/wm_mask_qc_report_all.pdf', 'wb') as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ torchvision
 future
 fpdf
 scikit-image
-PyPDF2
+pypdf
 lxml
 TIME-python
 scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
         'torch',
         #'dmipy',
         'lxml',
-        'PyPDF2',
+        'pypdf',
         'fpdf',
         'matplotlib',
         'cvxpy',


### PR DESCRIPTION
New version of PyPDF2 uses deprecated terms. PyPDF2 will no longer be maintained after version 3.0.X. This pull request changes the package PyPDF2 to pypdf, which will be be maintained in the future.